### PR TITLE
Remove fallback with image tags

### DIFF
--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -198,14 +198,6 @@ class OpenGraph implements Iterator
                 }
             } else if (!empty($page->_values['twitter_image'])){
 				$page->_values['image'] = $page->_values['twitter_image'];
-			} else {
-				$elements = $doc->getElementsByTagName("img");
-				foreach ( $elements as $tag ){
-					if ($tag->hasAttribute('width') && ( ($tag->getAttribute('width') > 300) || ($tag->getAttribute('width') == '100%') ) ){
-						$page->_values['image'] = $tag->getAttribute('src');
-						break;
-					}
-				}
 			}
         }
 


### PR DESCRIPTION
This pull request removes the `<img>` tag fallback for the `og:image`. 

Reasons for that: 
- Images URLs might be relative: Their URL would have to be prefixed to become absolute. To do this correctly, one would have to use the result of the curl redirect, which is not available at this point in code
- Images which are not designatet as sharing images, are probably not meant to be used as such.
- Facebook stopped using them as fallback
- People nowadays often use CSS for image widths instead of the "width" attribute